### PR TITLE
Authentication methods for partner/mgmt/acc keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ the following priority:
 1. Integrate with the
    [Management API](https://developer.vippsmobilepay.com/docs/APIs/management-api/),
    so the functionality is made available in the partner's own admin interface.
-   The Management API is designed and develop to enable as much self-service and
+   The Management API is designed and developed to enable as much self-service and
    automation as possible. Our
    [Partner terms and conditions](https://developer.vippsmobilepay.com/docs/partner/partner-terms/)
    state that partners are obligated to use the Management API.

--- a/README.md
+++ b/README.md
@@ -302,7 +302,11 @@ the following priority:
 1. Integrate with the
    [Management API](https://developer.vippsmobilepay.com/docs/APIs/management-api/),
    so the functionality is made available in the partner's own admin interface.
-2. Use the Management API manually with the Postman collection.
+   The Management API is designed and develop to enable as much self-service and
+   automation as possible. Our
+   [Partner terms and conditions](https://developer.vippsmobilepay.com/docs/partner/partner-terms/)
+   state that partners are obligated to use the Management API.
+2. Use the Management API manually with Postman.
 3. Ask the merchant to create a user for the partner on [portal.vipps.no](https://portal.vipps.no),
    so the partner can check on behalf of the merchant:
    [How to add a user on portal.vipps.no](https://developer.vippsmobilepay.com/docs/partner/add-portal-user).

--- a/partner-keys.md
+++ b/partner-keys.md
@@ -85,7 +85,7 @@ and the
 endpoint.
 
 Management keys and Accounting keys use a _new_ token endpoint:
-`POST:/miami/v1/token`.
+[`POST:/miami/v1/token`](https://developer.vippsmobilepay.com/api/access-token/#tag/Token-endpoint).
 
 ### An explanation for humans
 

--- a/partner-keys.md
+++ b/partner-keys.md
@@ -46,7 +46,7 @@ working to offer different type of partner keys:
 | ------------- | ----------- | ------ |
 | Partner keys | Provide access to the [Management API](https://developer.vippsmobilepay.com/docs/APIs/management-api/). Allow partners to initiate payments and move money on behalf of their merchants (for example, by using the [ePayment API](https://developer.vippsmobilepay.com/docs/APIs/epayment-api)). | Available now, see [Partner levels][level-url]. |
 | Management keys | Provide access to the [Management API](https://developer.vippsmobilepay.com/docs/APIs/management-api/). Cannot be used to move money. Both partners and merchants may use management keys. | Planned availability in Q4, aiming for late November. |
-| Accounting keys | Provide access to the [Report API](https://developer.vippsmobilepay.com/docs/APIs/report-api). Cannot be used to move money. | Planned availability in Q4, aiming for late November. |
+| Accounting keys | Provide access to the [Report API](https://developer.vippsmobilepay.com/docs/APIs/report-api). Cannot be used to move money. | Available now. |
 
 *Partner keys* are for partners who will make payments on behalf of their merchants.
 However, since the [Report API](https://developer.vippsmobilepay.com/docs/APIs/report-api) can
@@ -84,8 +84,11 @@ and the
 [`POST:/accesstoken/get`](https://developer.vippsmobilepay.com/api/access-token/#tag/Authorization-Service/operation/fetchAuthorizationTokenUsingPost)
 endpoint.
 
-Management keys and Accounting keys use a _new_ token endpoint:
+Partners using Management keys and Accounting keys use a _new_ token endpoint:
 [`POST:/miami/v1/token`](https://developer.vippsmobilepay.com/api/access-token/#tag/Token-endpoint).
+
+See:
+[Access token API: Two endpoints](https://developer.vippsmobilepay.com/docs/APIs/access-token-api/#two-endpoints).
 
 ### An explanation for humans
 

--- a/partner-keys.md
+++ b/partner-keys.md
@@ -69,7 +69,18 @@ On overview of which type of API keys give access to what:
 the partner will have two sets of API keys: Accounting keys and either Partner keys
 or Management keys.
 
-![Partner keys venn diagram](./images/partner-keys-venn-diagram.svg)
+![Partner keys Venn diagram](./images/partner-keys-venn-diagram.svg)
+
+### Authentication for the different types of API keys
+
+Partner keys use the well-known
+[Access token API](https://developer.vippsmobilepay.com/docs/APIs/access-token-api/)
+and the
+[`POST:/accesstoken/get`](https://developer.vippsmobilepay.com/api/access-token/#tag/Authorization-Service/operation/fetchAuthorizationTokenUsingPost)
+endpoint.
+
+Management keys and Accounting keys use a _new_ token endpoint:
+`POST:/authentication/v1/token`.
 
 ### An explanation for humans
 
@@ -99,6 +110,9 @@ The *accounting keys* only allow access to the
 [Report API](https://developer.vippsmobilepay.com/docs/APIs/report-api),
 for retrieval of data about payments that have been made.
 They cannot be used to manage sales units or to make payments.
+
+A partner that act both as a "normal" partner and as an accounrting partner
+will have both partner keys and accounting keys.
 
 ## Authentication
 
@@ -150,7 +164,7 @@ If you answer *YES* to any of the following questions, partner keys is **not** f
 
 ## Partner keys for different APIs
 
-The same set of partner keys can be used for all your merchants' sales units, for both the
+The same set of partner keys can be used for all your merchants' sales units, such as the
 [ePayment API](https://developer.vippsmobilepay.com/docs/APIs/epayment-api/)
 and the
 [Recurring API](https://developer.vippsmobilepay.com/docs/APIs/recurring-api),

--- a/partner-keys.md
+++ b/partner-keys.md
@@ -85,7 +85,7 @@ and the
 endpoint.
 
 Management keys and Accounting keys use a _new_ token endpoint:
-`POST:/authentication/v1/token`.
+`POST:/miami/v1/token`.
 
 ### An explanation for humans
 

--- a/partner-keys.md
+++ b/partner-keys.md
@@ -116,8 +116,7 @@ The *accounting keys* only allow access to the
 for retrieval of data about payments that have been made.
 They cannot be used to manage sales units or to make payments.
 
-A partner that act both as a "normal" partner and as an accounrting partner
-will have both partner keys and accounting keys.
+Accounting keys are separate and do not have overlapping functionality with the other types of partner keys. Partners who have either *partner keys* or *management keys* will need a separate set of *accounting keys* to access the Report API
 
 ## Authentication
 


### PR DESCRIPTION
We need to document:
* Partner keys: Same as before: Access token API: `POST:/accesstoken/get`
* Management keys: New stuff!  Now: `POST:/miami/v1/token`. Later: `POST:/authentication/v1/token`
* Accounting keys: : New stuff! Now: `POST:/miami/v1/token` Later: `POST:/authentication/v1/token`

Some of the places we need to update:
- https://developer.vippsmobilepay.com/docs/APIs/access-token-api/ - add short info at the start: Two types, then MIAMI details at the bottom of the page.
- https://developer.vippsmobilepay.com/docs/partner/partner-keys/ - Link to the above.
- https://developer.vippsmobilepay.com/api/access-token/ - Add MIAMI endpoints to thew same YAML

This won't be perfect, but as long as it is clear and understandable, it's OK.

See https://github.com/vippsas/access-token-api/pull/16